### PR TITLE
Require react-dom/server for renderTo* functions

### DIFF
--- a/lib/Component.js
+++ b/lib/Component.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var ReactDOMServer = require('react-dom/server');
 var path = require('path');
 
 var Component = function Component(opts) {
@@ -69,8 +70,10 @@ Component.prototype._render = function _render(props, toStaticMarkup, cb) {
     if (err) return cb(err);
 
     var render = (
-      toStaticMarkup ? React.renderToStaticMarkup : React.renderToString
-    ).bind(React);
+      toStaticMarkup
+        ? ReactDOMServer.renderToStaticMarkup
+        : ReactDOMServer.renderToString
+    ).bind(ReactDOMServer);
 
     try {
       var markup = render(factory(props));

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "mocha": "^2.2.5",
-    "react": "^0.13.3"
+    "react": "^0.14.2",
+    "react-dom": "^0.14.2"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
I tried to update to 0.14. Apparently that's all I need.

I get a test failure on the SyntaxError component, but I do get it with 0.13 as well so that's another problem.

EDIT: In response to #2 