### PR TITLE
Babel 6 export default support

### DIFF
--- a/lib/Component.js
+++ b/lib/Component.js
@@ -38,6 +38,9 @@ Component.prototype.getComponent = function getComponent(cb) {
 
     try {
       this.component = require(this.path);
+      if (this.component && typeof this.component === 'object' && this.component.default) {
+        this.component = this.component.default
+      }
     } catch(err) {
       return cb(err);
     }


### PR DESCRIPTION
I am using recently released Babel 6 for transpiling ES6 react components. I am exporting component like this:
```js
import React from 'react';
class Test extends React.Component {
  render() {
    return <div>Test</div>;
  }
}
export default Test;
```
Imported component via `require` results in object instead of exported function and throws an error.
Link to issue: https://github.com/babel/babel/issues/2724

This PR adds a check for a not null object with key 'default' and uses that as a component. 